### PR TITLE
chore(code): remove eslint.packageManager setting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,6 @@
 	"editor.foldingImportsByDefault": true,
 	"editor.formatOnSave": true,
 	"editor.tabSize": 2,
-	"eslint.packageManager": "yarn",
 	"files.exclude": {
 		"**/.stylelintcache": true,
 		"**/.eslintcache": true,


### PR DESCRIPTION
This setting has no effect as we are not using the package globally.