### PR TITLE
Fixing prettier for Windows

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -3,7 +3,7 @@
 	"bracketSameLine": false,
 	"bracketSpacing": true,
 	"jsxSingleQuote": true,
-	"plugins": ["./node_modules/prettier-plugin-tailwindcss/dist/index.mjs"],
+	"plugins": ["prettier-plugin-tailwindcss"],
 	"printWidth": 80,
 	"quoteProps": "as-needed",
 	"semi": false,


### PR DESCRIPTION
Took a while to figure out, but on windows this config fails with:

```
Only URLs with a scheme in: file and data are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'
```

Looking at `prettier` docs, the plugin references are direct not relative file system based.